### PR TITLE
Mac support plus Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
+SRC=log.cpp pch.cpp plugin.cpp
+INC=framework.h log.h pch.h plugin.h buffer.hpp data_parser.hpp packet_data.hpp received_control.hpp received_tile.hpp
+
+UNAME=$(shell uname)
+
+ifeq ($(UNAME), Darwin)
+OUTPUT=libWebRTCConnector.dylib
 CC=clang++
 CFLAGS=--std=c++14 -arch x86_64 -arch arm64
 LDFLAGS=-dynamiclib
-SRC=log.cpp pch.cpp plugin.cpp
-INC=framework.h log.h pch.h plugin.h buffer.hpp data_parser.hpp packet_data.hpp received_control.hpp received_tile.hpp
-OUTPUT=libWebRTCConnector.dylib
+endif
+ifeq ($(UNAME), Linux)
+OUTPUT=libWebRTCConnector.so
+CC=g++
+CFLAGS=--std=c++14
+LDFLAGS=-shared
+endif
 
 $(OUTPUT): $(SRC) $(INC)
 	$(CC) $(LDFLAGS) $(CFLAGS) $(SRC) -o $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+CC=clang++
+CFLAGS=--std=c++14 -arch x86_64 -arch arm64
+LDFLAGS=-dynamiclib
+SRC=log.cpp pch.cpp plugin.cpp
+INC=framework.h log.h pch.h plugin.h buffer.hpp data_parser.hpp packet_data.hpp received_control.hpp received_tile.hpp
+OUTPUT=libWebRTCConnector.dylib
+
+$(OUTPUT): $(SRC) $(INC)
+	$(CC) $(LDFLAGS) $(CFLAGS) $(SRC) -o $(OUTPUT)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the Unity plugin that can be used to communicate with the L4S WSL2 client. You can build the plugin with Visual Studio (make sure you build the release version and not the debug one) and copy the .dll file to your Unity application.
 
+> Note by Jack: there's now also a `Makefile` to build the plugin on Mac (tested) and Linux (untested).
+
 If you are using WSL and you want to know what ip to use check: https://github.ugent.be/madfr/l4s-proxy-windows-testapp
 
 ## C# Examples

--- a/framework.h
+++ b/framework.h
@@ -1,13 +1,35 @@
 #pragma once
 
+#ifdef WIN32
 // Exclude rarely-used stuff from Windows headers
 #define WIN32_LEAN_AND_MEAN
-
 // Include Windows header files
 #include <windows.h>
-#include <stdio.h>
 #include <winsock2.h>
 #include <Ws2tcpip.h>
+// Winsock Library
+#pragma comment(lib,"ws2_32.lib")
+
+#define DLLExport __declspec(dllexport)
+#else
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <time.h>
+
+typedef int SOCKET;
+typedef unsigned long ULONG;
+const int SOCKET_ERROR = -1;
+inline void WSACleanup() {}
+inline int WSAGetLastError() { return errno; }
+inline int closesocket(int socket) { return close(socket); }
+#define DLLExport
+
+#endif
+
+#include <stdio.h>
 #include <iostream>
 #include <chrono>
 #include <memory.h>
@@ -17,5 +39,3 @@
 #include <thread>
 #include <mutex>
 
-// Winsock Library
-#pragma comment(lib,"ws2_32.lib") 

--- a/framework.h
+++ b/framework.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef WIN32
+#if defined(_WIN32) || defined(_WIN64)
 // Exclude rarely-used stuff from Windows headers
 #define WIN32_LEAN_AND_MEAN
 // Include Windows header files

--- a/log.h
+++ b/log.h
@@ -4,8 +4,7 @@
 #include <string>
 #include <stdio.h>
 #include <sstream>
-
-#define DLLExport __declspec(dllexport)
+#include "framework.h"
 
 extern "C"
 {

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -20,7 +20,9 @@
 using namespace std;
 
 bool one_socket = true;
+#ifdef WIN32
 static WSADATA wsa;
+#endif
 static struct sockaddr_in si_send;
 static SOCKET s_send;
 int slen_send = sizeof(si_send);
@@ -62,7 +64,8 @@ inline string get_current_date_time(bool date_only) {
 	time_t now = time(0);
 	char buf[80];
 	struct tm tstruct;
-	localtime_s(&tstruct, &now);
+    // xxxjack I think the parameters were in the wrong order...
+	localtime_r( &now, &tstruct);
 	if (date_only) {
 		strftime(buf, sizeof(buf), "%Y-%m-%d", &tstruct);
 	} else {
@@ -105,10 +108,12 @@ int connect_to_proxy(char* ip_send, uint32_t port_send, char* ip_recv, uint32_t 
 	tile_buffer.set_number_of_tiles(number_of_tiles);
 	data_parser.set_number_of_tiles(number_of_tiles);
 
+#ifdef WIN32
 	custom_log("Setting up socket to " + string(ip_send), false, Color::Orange);
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
 		return StartUpError;
 	}
+#endif
 	// Generic parameters
 	ULONG buf_size = 524288000;
 	char t[BUFLEN] = { 0 };
@@ -122,7 +127,11 @@ int connect_to_proxy(char* ip_send, uint32_t port_send, char* ip_recv, uint32_t 
 	setsockopt(s_send, SOL_SOCKET, SO_RCVBUF, (char*)&buf_size, sizeof(ULONG));
 	si_send.sin_family = AF_INET;
 	si_send.sin_port = htons(port_send);
-	inet_pton(AF_INET, ip_send, &si_send.sin_addr.S_un.S_addr);
+#ifdef WIN32
+    inet_pton(AF_INET, ip_send, &si_send.sin_addr.S_un.S_addr);
+#else
+    inet_pton(AF_INET, ip_send, &si_send.sin_addr.s_addr);
+#endif
 	if (sendto(s_send, t, BUFLEN, 0, (struct sockaddr*)&si_send, slen_send) == SOCKET_ERROR) {
 		custom_log("ERROR: failed to send to socket on port " + to_string(port_send), false, Color::Red);
 		WSACleanup();
@@ -141,8 +150,12 @@ int connect_to_proxy(char* ip_send, uint32_t port_send, char* ip_recv, uint32_t 
 		setsockopt(s_recv, SOL_SOCKET, SO_RCVBUF, (char*)&buf_size, sizeof(ULONG));
 		si_recv.sin_family = AF_INET;
 		si_recv.sin_port = htons(port_recv);
-		inet_pton(AF_INET, ip_recv, &si_recv.sin_addr.S_un.S_addr);
-		if (sendto(s_recv, t, BUFLEN, 0, (struct sockaddr*)&si_recv, slen_recv) == SOCKET_ERROR) {
+#ifdef WIN32
+        inet_pton(AF_INET, ip_recv, &si_recv.sin_addr.S_un.S_addr);
+#else
+        inet_pton(AF_INET, ip_recv, &si_recv.sin_addr.s_addr);
+#endif
+        if (sendto(s_recv, t, BUFLEN, 0, (struct sockaddr*)&si_recv, slen_recv) == SOCKET_ERROR) {
 			custom_log("ERROR: failed to send to socket on port " + to_string(port_recv), false, Color::Red);
 			WSACleanup();
 			return SendToError;
@@ -166,7 +179,7 @@ void listen_for_data() {
 		if (one_socket) {
 			custom_log("About to receive from s_send", false, Color::Yellow);
 			if ((size = recvfrom(s_send, buf, BUFLEN, 0, NULL, NULL)) == SOCKET_ERROR) {
-				custom_log("ERROR: recvfrom() failed with error code " + WSAGetLastError(), true, Color::Red);
+				custom_log("ERROR: recvfrom() failed with error code " + std::to_string(WSAGetLastError()), true, Color::Red);
 				guard.unlock();
 				return;
 			}
@@ -174,7 +187,7 @@ void listen_for_data() {
 		} else {
 			custom_log("About to receive from s_recv", false, Color::Yellow);
 			if ((size = recvfrom(s_recv, buf, BUFLEN, 0, NULL, NULL)) == SOCKET_ERROR) {
-				custom_log("ERROR: recvfrom() failed with error code " + WSAGetLastError(), true, Color::Red);
+				custom_log("ERROR: recvfrom() failed with error code " + std::to_string(WSAGetLastError()), true, Color::Red);
 				guard.unlock();
 				return;
 			}

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -64,8 +64,11 @@ inline string get_current_date_time(bool date_only) {
 	time_t now = time(0);
 	char buf[80];
 	struct tm tstruct;
-    // xxxjack I think the parameters were in the wrong order...
+#if defined(_WIN64) || defined(_WIN32)
+	localtime_s(&tstruct, &now);
+#else
 	localtime_r( &now, &tstruct);
+#endif
 	if (date_only) {
 		strftime(buf, sizeof(buf), "%Y-%m-%d", &tstruct);
 	} else {

--- a/plugin.h
+++ b/plugin.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef WIN32
 #define DLLExport __declspec(dllexport)
+#else
+#define DLLExport
+#endif
 
 // All exported functions should be declared here
 extern "C"


### PR DESCRIPTION
The changes to the sourcefiles are mainly putting the Windows-specific includes within `#ifdef WIN32` and the MacOS/Linux includes in the `#else`.

There's also a minimal `Makefile` that builds the dylib on MacOS. Linux should be very similar, but maybe we should switch to `cmake` to have a universal set of build instructions.